### PR TITLE
clean: Markdown headings separate from paragraphs

### DIFF
--- a/statistical_distributions.ipynb
+++ b/statistical_distributions.ipynb
@@ -31,8 +31,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Agenda:\n",
-    "   \n",
+    "## Agenda:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "SWBAT:\n",
     "- 1. Describe the difference between discrete and continuous random variables;\n",
     "- 2. Describe the difference between PMFs, PDFs, and CDFs;\n",
@@ -44,8 +49,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## What is a statistical distribution?\n",
-    "\n",
+    "## What is a statistical distribution?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "- A statistical distribution is a representation of the frequencies of potential events or the percentage of time each event occurs."
    ]
   },
@@ -53,8 +63,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Discrete vs. Continuous\n",
-    "\n",
+    "## Discrete vs. Continuous"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "We will learn about a variety of different probability distributions, but before we do so, we need to establish the difference between **discrete** and **continuous** variables."
    ]
   },
@@ -62,8 +77,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Discrete\n",
-    "\n",
+    "### Discrete"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     ">  With discrete distributions, the values can only take a finite set of values.  Take, for example, a roll of a single six-sided die. "
    ]
   },
@@ -85,8 +105,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Examples of discrete distributions:\n",
-    "\n",
+    "#### Examples of discrete distributions:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "- **Uniform Distribution**\n",
     "    - occurs when all possible outcomes are equally likely.\n",
     "- **Bernoulli Distribution**\n",
@@ -94,15 +119,20 @@
     "- **Binomial Distribution**\n",
     "    - represents the probability of observing a specific number of successes (Bernoulli trials) in a specific number of trials.\n",
     "- **Poisson Distribution**\n",
-    "    - represents the probability of 𝑛 events in a given time period when the overall rate of occurrence is constant.\n"
+    "    - represents the probability of 𝑛 events in a given time period when the overall rate of occurrence is constant."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Continuous\n",
-    "\n",
+    "### Continuous"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "With a continuous distribution, the set of possible results is an infinite set of values within a range. Think about measuring the length of something. The reported measurement can always be more or less precise.\n",
     "\n",
     "![](images/pdf.png)"
@@ -112,8 +142,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Examples of continuous distributions\n",
-    "\n",
+    "#### Examples of continuous distributions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "- **Continuous Uniform**;\n",
     "- **Normal or Gaussian**;\n",
     "- **Exponential**"
@@ -186,8 +221,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Expected Value/Mean\n",
-    "\n",
+    "### Expected Value/Mean"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The expected value, or the mean, describes the 'center' of the distribution (you may hear this called the first moment).  The 'center' refers loosely to the middle-values of a distribution, and is measured more precisely by notions like the mean, the median, and the mode.\n",
     "\n",
     "For a discrete distribution, working from the vantage point of a collected sample of n data points:\n",
@@ -204,7 +244,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Variance/Standard Deviation\n",
+    "### Variance/Standard Deviation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Variance describes the spread of the data (it is also referred to as the second moment).  The 'spread' refers loosely to how far away the more extreme values are from the center.\n",
     "\n",
     "Standard deviation is the square root of variance, and effectively measures the *average distance away from the mean*.\n",
@@ -262,12 +308,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## PDF: Probability Density Function\n",
-    "\n",
+    "## PDF: Probability Density Function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "> Probability density functions are similar to PMFs, in that they describe the probability of a result within a range of values. But where PMFs are appropriate for discrete variables and so can be descibed with barplots, PDFs are smooth curves that describe continuous random variables.  \n",
     "\n",
-    "![](images/pdf_temp.png)\n",
-    "\n"
+    "![](images/pdf_temp.png)"
    ]
   },
   {
@@ -283,8 +333,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Expected value and variance for PDFs:\n",
-    "\n",
+    "### Expected value and variance for PDFs:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "![](images/exp_v_pdf.png)"
    ]
   },
@@ -377,8 +432,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Skewed Distributions\n",
-    "\n",
+    "### Skewed Distributions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Recall the third moment of a statistical distribution: skew. A skew of zero is perfectly symmetrical about the mean.   \n",
     "\n",
     "![skew](images/skew.png)"
@@ -400,18 +460,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Transforming  Right/Positively Skewed Data\n",
-    "\n",
+    "#### Transforming  Right/Positively Skewed Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "We may want to transform our skewed data to make it approach symmetry.\n",
     "\n",
-    "Common transformations of this data include \n",
-    "\n",
-    "##### Root Transformations:\n",
-    "\n",
-    "- $x \\rightarrow\\sqrt[n]{x}$\n",
-    "\n",
-    "##### Logarithmic Transformations:\n",
-    "\n",
+    "Common transformations of this data include "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Root Transformations:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- $x \\rightarrow\\sqrt[n]{x}$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Logarithmic Transformations:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "- $x \\rightarrow\\log_n{x}$"
    ]
   },
@@ -419,10 +504,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Transforming Left/Negatively Skewed Data\n",
-    "\n",
-    "##### Power Transformations:\n",
-    "\n",
+    "#### Transforming Left/Negatively Skewed Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Power Transformations:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "- $x\\rightarrow x^n$"
    ]
   },
@@ -430,8 +525,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Kurtosis\n",
-    "\n",
+    "### Kurtosis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "![kurtosis](images/kurtosis.png)"
    ]
   },
@@ -439,8 +539,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## CDF: Cumulative Distribution Function\n",
-    "\n",
+    "## CDF: Cumulative Distribution Function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "![](images/cdf.png)"
    ]
   },
@@ -592,8 +697,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Bernoulli and Binomial Distributions\n",
-    "\n",
+    "### Bernoulli and Binomial Distributions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The Bernoulli Distribution is the discrete distribution that describes a two-outcome trial, such as a coin toss. The distribution is described by the probability $p$ of one random variable taking the value 1 and by the corrleative probability $q$, associated with 0 and taking the probability 1-p. \n",
     "\n",
     "PMF: \n",
@@ -708,8 +818,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Poisson Distribution\n",
-    "\n",
+    "### Poisson Distribution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The Poisson distribution describes the probability of a certain number of a specific type of event occuring over a given interval. We assume that these events are probabilistically independent.\n",
     "\n",
     "Examples:\n",
@@ -901,8 +1016,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Empirical Rule\n",
-    "\n",
+    "### Empirical Rule"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "> The Empirical or 68–95–99.7 Rule states that 68% of the values of a normal distribution of data lie within 1 standard deviation of the mean, 95% within 2 stds, and 99.7 within three.  \n",
     "> The empirical rule has many applications in data science."
    ]
@@ -911,8 +1031,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### $z$-Score\n",
-    "\n",
+    "### $z$-Score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "A $z$-score for a data point x (in a normal distribution) is simply the distance to the mean in units of standard deviations. That is:\n",
     "\n",
     "$z = \\frac{x - \\mu}{\\sigma}$.\n",
@@ -987,7 +1112,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Separating the headings from the paragraphs allow better use of
  Markdown section folding (Collapsible Headings extension).

Closes enhancement #1 